### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -14,8 +14,8 @@ You'll clone a sample Spring Boot application from GitHub and then use Maven to 
 The following prerequisites are required in order to follow the steps in this article:
 
 * An Azure subscription. If you don't already have an Azure subscription, you can sign up for a https://azure.microsoft.com/pricing/free-trial/[free Azure account] or activate your https://azure.microsoft.com/pricing/member-offers/msdn-benefits-details/[MSDN subscriber benefits].
-* The http://docs.microsoft.com/cli/azure/overview[Azure Command-Line Interface (CLI)].
-* An up-to-date http://www.oracle.com/technetwork/java/javase/downloads/[Java Development Kit (JDK)], version 1.8 or later.
+* The https://docs.microsoft.com/cli/azure/overview[Azure Command-Line Interface (CLI)].
+* An up-to-date https://www.oracle.com/technetwork/java/javase/downloads/[Java Development Kit (JDK)], version 1.8 or later.
 * A https://github.com/[Git] client.
 
 == Create a sample Spring Boot web app
@@ -46,7 +46,7 @@ Azure should print out a JSON response resembling this:
 {
    "appId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
    "displayName": "uuuuuuuu",
-   "name": "http://uuuuuuuu",
+   "name": "https://uuuuuuuu",
    "password": "pppppppp",
    "tenant": "tttttttt-tttt-tttt-tttt-tttttttttttt"
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://uuuuuuuu (UnknownHostException) with 1 occurrences migrated to:  
  https://uuuuuuuu ([https](https://uuuuuuuu) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.microsoft.com/cli/azure/overview with 1 occurrences migrated to:  
  https://docs.microsoft.com/cli/azure/overview ([https](https://docs.microsoft.com/cli/azure/overview) result 301).
* [ ] http://www.oracle.com/technetwork/java/javase/downloads/ with 1 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/downloads/ ([https](https://www.oracle.com/technetwork/java/javase/downloads/) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 2 occurrences