### PR TITLE
support consumption plan as a option

### DIFF
--- a/infra/abbreviations.json
+++ b/infra/abbreviations.json
@@ -4,6 +4,7 @@
   "appConfigurationConfigurationStores": "appcs-",
   "appManagedEnvironments": "cae-",
   "appContainerApps": "ca-",
+  "appContainerAppsManagedEnvironment": "env-",
   "authorizationPolicyDefinitions": "policy-",
   "automationAutomationAccounts": "aa-",
   "blueprintBlueprints": "bp-",

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -16,10 +16,10 @@ param principalId string = ''
 param relativePath string
 
 @allowed([
-  'Consumption'
-  'Standard'
+  'consumption'
+  'standard'
 ])
-param plan string
+param plan string = 'consumption'
 
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
@@ -39,7 +39,7 @@ resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   tags: tags
 }
 
-module springAppsConsumption 'modules/springapps/springappsConsumption.bicep' = if (plan == 'Consumption') {
+module springAppsConsumption 'modules/springapps/springappsConsumption.bicep' = if (plan == 'consumption') {
   name: '${deployment().name}--asaconsumption'
   scope: resourceGroup(rg.name)
   params: {
@@ -52,7 +52,7 @@ module springAppsConsumption 'modules/springapps/springappsConsumption.bicep' = 
   }
 }
 
-module springAppsStandard 'modules/springapps/springappsStandard.bicep' = if (plan == 'Standard') {
+module springAppsStandard 'modules/springapps/springappsStandard.bicep' = if (plan == 'standard') {
   name: '${deployment().name}--asastandard'
   scope: resourceGroup(rg.name)
   params: {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -19,7 +19,7 @@ param relativePath string
   'Consumption'
   'Standard'
 ])
-param tier string
+param plan string
 
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
@@ -39,7 +39,7 @@ resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   tags: tags
 }
 
-module springAppsConsumption 'modules/springapps/springappsConsumption.bicep' = if (tier == 'Consumption') {
+module springAppsConsumption 'modules/springapps/springappsConsumption.bicep' = if (plan == 'Consumption') {
   name: '${deployment().name}--asaconsumption'
   scope: resourceGroup(rg.name)
   params: {
@@ -52,7 +52,7 @@ module springAppsConsumption 'modules/springapps/springappsConsumption.bicep' = 
   }
 }
 
-module springAppsStandard 'modules/springapps/springappsStandard.bicep' = if (tier == 'Standard') {
+module springAppsStandard 'modules/springapps/springappsStandard.bicep' = if (plan == 'Standard') {
   name: '${deployment().name}--asastandard'
   scope: resourceGroup(rg.name)
   params: {

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -13,6 +13,9 @@
     },
     "relativePath": {
       "value": "${SERVICE_DEMO_RELATIVE_PATH=<default>}"
+    },
+    "plan": {
+      "value": "${PLAN=consumption}"
     }
   }
 }

--- a/infra/modules/springapps/springappsConsumption.bicep
+++ b/infra/modules/springapps/springappsConsumption.bicep
@@ -1,0 +1,63 @@
+param location string = resourceGroup().location
+param asaManagedEnvironmentName string
+param asaInstanceName string
+param appName string
+param tags object = {}
+param relativePath string
+
+resource asaManagedEnvironment 'Microsoft.App/managedEnvironments@2022-11-01-preview' = {
+  name: asaManagedEnvironmentName
+  location: location
+  tags: tags
+  properties: {
+	workloadProfiles: [
+	  {
+	    name: 'Consumption'
+		workloadProfileType: 'Consumption'
+	  }
+    ]
+  }
+}
+
+resource asaInstance 'Microsoft.AppPlatform/Spring@2023-03-01-preview' = {
+  name: asaInstanceName
+  location: location
+  tags: union(tags, { 'azd-service-name': appName })
+  sku: {
+    name: 'S0'
+	tier: 'StandardGen2'
+  }
+  properties: {
+	managedEnvironmentId: asaManagedEnvironment.id
+  }
+}
+
+resource asaApp 'Microsoft.AppPlatform/Spring/apps@2023-03-01-preview' = {
+  name: appName
+  location: location
+  parent: asaInstance
+  properties: {
+    public: true
+  }
+}
+
+resource asaDeployment 'Microsoft.AppPlatform/Spring/apps/deployments@2023-03-01-preview' = {
+  name: 'default'
+  parent: asaApp
+  properties: {
+    source: {
+      type: 'Jar'
+      relativePath: relativePath
+      runtimeVersion: 'Java_17'
+    }
+    deploymentSettings: {
+      resourceRequests: {
+        cpu: '1'
+        memory: '2Gi'
+      }
+    }
+  }
+}
+
+output name string = asaApp.name
+output uri string = 'https://${asaApp.properties.url}'

--- a/infra/modules/springapps/springappsStandard.bicep
+++ b/infra/modules/springapps/springappsStandard.bicep
@@ -7,10 +7,10 @@ param relativePath string
 resource asaInstance 'Microsoft.AppPlatform/Spring@2022-12-01' = {
   name: asaInstanceName
   location: location
-  tags: tags
+  tags: union(tags, { 'azd-service-name': appName })
   sku: {
-      name: 'B0'
-      tier: 'Basic'
+      name: 'S0'
+      tier: 'Standard'
     }
 }
 
@@ -20,7 +20,6 @@ resource asaApp 'Microsoft.AppPlatform/Spring/apps@2022-12-01' = {
   parent: asaInstance
   properties: {
     public: true
-    activeDeploymentName: 'default'
   }
 }
 


### PR DESCRIPTION
This is pr is to make the AZD template support both ASA consumption plan and standard plan, and the default option will be the consumption plan.

To test it, you can run:
```
mkdir gs-spring-boot-for-azure
cd gs-spring-boot-for-azure
azd auth login
azd config set alpha.springapp on
azd init --template https://github.com/yiliuTo/gs-spring-boot-for-azure/ -b support-consumption
azd up
```

The template by default uses consumption plan, and if users want to use standard, they can set `azd env set PLAN standard` then run `azd up`. If users have already provisioned the resources with the consumption plan and want to try the Standard plan, they need to run azd down first to delete the resources, and then run azd env set PLAN standard and azd up again to provision and deploy.
