### PR TITLE
support beta feature

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/alpha/azure.yaml.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
 
 name: gs-spring-boot-for-azure
 metadata:


### PR DESCRIPTION
The ASA-AZD integration will go to beta feature soon. This pr is to resolve https://github.com/Azure/azure-dev/issues/2503 to update the template compatible with the beta feature. Thus, it should not be merged until AZD releases ASA as the beta feature, ref https://github.com/Azure/azure-dev/milestone/18.

When AZD 1.2.0 gets released, run the following commands:
```
mkdir gs-spring-boot-for-azure
cd gs-spring-boot-for-azure
azd auth login
azd init --template https://github.com/yiliuTo/gs-spring-boot-for-azure -b support-beta
azd up
```