### PR TITLE
remove unnecessary configuration in azure.yaml

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -8,5 +8,3 @@ services:
     project: ./complete/
     host: springapp
     language: java
-    spring:
-      deploymentName: default


### PR DESCRIPTION
As subject, this pr is to resolve https://github.com/spring-guides/gs-spring-boot-for-azure/pull/18#discussion_r1291620187, the configuration for deployment name as `default` for ASA is unnecessary since it has been the default value.